### PR TITLE
Fix typo in rdbHelper1: Change "秒內" to "秒内"

### DIFF
--- a/frontend/src/lang/modules/zh.ts
+++ b/frontend/src/lang/modules/zh.ts
@@ -563,7 +563,7 @@ const message = {
         restartNowHelper: '修改配置后需要重启生效。',
 
         persistence: '持久化',
-        rdbHelper1: '秒內,插入',
+        rdbHelper1: '秒内,插入',
         rdbHelper2: '条数据',
         rdbHelper3: '符合任意一个条件将会触发RDB持久化',
         rdbInfo: '请确认规则列表中值在 1-100000 之间',


### PR DESCRIPTION
问题：在 frontend/src/lang/modules/zh.ts 文件中，rdbHelper1 的值中使用了**繁体字**“內”，与项目简体中文规范不一致。

修复：将“秒內,插入”修正为“秒内,插入”，确保语言一致性。

影响范围：仅影响中文语言包中的 rdbHelper1 提示文本，未影响其他功能。

测试：已验证修改后界面显示正常，无其他副作用。